### PR TITLE
Issue#4: added jest configuration to specify the folder of executable tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  rootDir: "./src",
+};


### PR DESCRIPTION
This configuration closes #4
Set up the rootDir of jest to watch the 'src' directory, so we can leave the build and stuff to jest. 